### PR TITLE
Removing RNGH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,9 @@ local.properties
 
 # node.js
 #
+coverage/
 node_modules/
+test-report.xml
 npm-debug.log
 yarn-error.log
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@marcuzgabriel/reanimated-bottom-sheet",
   "author": "Marcuz Gabriel Larsen <marcuzgabriel@gmail.com>",
-  "version": "1.0.9",
+  "version": "1.0.3",
   "license": "MIT",
   "scripts": {
     "android": "react-native run-android",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@marcuzgabriel/reanimated-bottom-sheet",
   "author": "Marcuz Gabriel Larsen <marcuzgabriel@gmail.com>",
-  "version": "1.0.2",
+  "version": "1.0.9",
   "license": "MIT",
   "scripts": {
     "android": "react-native run-android",
@@ -21,7 +21,7 @@
     "type:generate:clean": "cross-env-shell rimraf lib",
     "type:generate:create": "cross-env-shell mkdir lib",
     "type:generate:tsc": "yarn tsc",
-    "type:generate:delete:tests": "cross-env-shell rimraf ./lib/worklets/__tests__ && rimraf ./lib/helpers/__tests__",
+    "type:generate:delete:tests": "cross-env-shell rimraf ./lib/worklets/__tests__ && rimraf ./lib/helpers/__tests__ && rimraf ./lib/worklets/gestures",
     "type:generate:delete:files:linux": "cross-env-shell del \"lib\\index.js && cross-env-shell del \"lib\\*.web.js && cross-env-shell del \"lib\\ReanimatedAnimationLibrary.js",
     "type:generate:delete:files:unix": "rm ./lib/index.js && rm ./lib/index.web.js && rm ./lib/ReanimatedAnimationLibrary.js",
     "type:generate:copy:linux": "cross-env-shell Xcopy \"src\\ReanimatedAnimationLibrary.ts\" \"lib\\index.js*\" /Y",
@@ -102,7 +102,7 @@
     "react-dom": "17.0.2",
     "react-native": "0.68.2",
     "react-native-gesture-handler": "^2.4.2",
-    "react-native-reanimated": "^2.9.1",
+    "react-native-reanimated": "2.8.0",
     "react-native-redash": "^16.2.4",
     "react-native-svg": "12.2.0",
     "react-native-svg-web": "^1.0.9",

--- a/src/components/ScrollViewKeyboardAvoid/ScrollView/index.tsx
+++ b/src/components/ScrollViewKeyboardAvoid/ScrollView/index.tsx
@@ -20,7 +20,6 @@ import { ANDROID_FADING_EDGE_LENGTH } from '../../../constants/configs';
 import KeyboardAvoidingViewProvider from '../../../containers/KeyboardAvoidingViewProvider';
 import { KeyboardContext } from '../../../containers/KeyboardProvider';
 import type { ScrollViewProps } from '../../../types';
-import { GestureDetector } from 'react-native-gesture-handler';
 
 const AnimatedWrapper = Animated.createAnimatedComponent(styled.View``);
 const isWeb = Platform.OS === 'web';
@@ -34,7 +33,6 @@ const ScrollView: React.FC<ScrollViewProps> = props => {
     isKeyboardAvoidDisabled,
     scrollArrows,
     translationYValues,
-    gesture,
     scrollTo,
     onContentSizeChange,
     onIsInputFieldFocusedRequest,
@@ -215,34 +213,34 @@ const ScrollView: React.FC<ScrollViewProps> = props => {
         />
       )}
       {scrollArrows?.isEnabled && <ScrollArrow {...scrollArrowProps} position="top" />}
-      <GestureDetector gesture={gesture}>
-        <Animated.ScrollView
-          {...props}
-          ref={scrollViewRef}
-          fadingEdgeLength={isFadingScrollEdgeEnabled ? fadingEdgeAndroid : 0}
-          onLayout={onLayout}
-          onScroll={onScrollHandler}
-          onContentSizeChange={(width, height): void => {
-            if (typeof onContentSizeChange === 'function') {
-              onContentSizeChange(width, height);
-            }
 
-            contentHeight.value = height;
-          }}
+      <Animated.ScrollView
+        {...props}
+        ref={scrollViewRef}
+        fadingEdgeLength={isFadingScrollEdgeEnabled ? fadingEdgeAndroid : 0}
+        onLayout={onLayout}
+        onScroll={onScrollHandler}
+        onContentSizeChange={(width, height): void => {
+          if (typeof onContentSizeChange === 'function') {
+            onContentSizeChange(width, height);
+          }
+
+          contentHeight.value = height;
+        }}
+      >
+        <KeyboardAvoidingViewProvider
+          isInputFieldFocused={isInputFieldFocused}
+          translationYValues={translationYValues}
+          isKeyboardAvoidDisabled={isKeyboardAvoidDisabled}
+          isFocusInputFieldAnimationRunning={isFocusInputFieldAnimationRunning}
+          contentHeight={contentHeight}
+          keyboardAvoidBottomMargin={keyboardAvoidBottomMargin}
+          onIsInputFieldFocusedRequest={onIsInputFieldFocusedRequest}
         >
-          <KeyboardAvoidingViewProvider
-            isInputFieldFocused={isInputFieldFocused}
-            translationYValues={translationYValues}
-            isKeyboardAvoidDisabled={isKeyboardAvoidDisabled}
-            isFocusInputFieldAnimationRunning={isFocusInputFieldAnimationRunning}
-            contentHeight={contentHeight}
-            keyboardAvoidBottomMargin={keyboardAvoidBottomMargin}
-            onIsInputFieldFocusedRequest={onIsInputFieldFocusedRequest}
-          >
-            {children}
-          </KeyboardAvoidingViewProvider>
-        </Animated.ScrollView>
-      </GestureDetector>
+          {children}
+        </KeyboardAvoidingViewProvider>
+      </Animated.ScrollView>
+
       {scrollArrows?.isEnabled && <ScrollArrow {...scrollArrowProps} position="bottom" />}
       {isFadingScrollEdgeEnabled && (
         <FadingEdge

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -187,7 +187,6 @@ interface ScrollViewProps extends ScrollViewNativeProps {
   onContentSizeChange?: (width: number, height: number) => void;
   onIsInputFieldFocusedRequest?: (status: boolean, availableHeight: number) => void;
   children: React.ReactNode;
-  gesture?: SimultaneousGesture;
   isKeyboardAvoidDisabled?: boolean;
   keyboardAvoidBottomMargin?: number;
   connectScrollViewMeasuresToAnimationValues?: Record<

--- a/src/worklets/__tests__/onGestureHandlerCard.test.ts
+++ b/src/worklets/__tests__/onGestureHandlerCard.test.ts
@@ -1,0 +1,357 @@
+import Animated, { useSharedValue } from 'react-native-reanimated';
+import { renderHook } from '@testing-library/react-hooks';
+import { onGestureHandlerCard } from '../onGestureHandlerCard';
+
+const {
+  withReanimatedTimer,
+  advanceAnimationByTime,
+} = require('react-native-reanimated/lib/reanimated2/jestUtils');
+
+const ADVANCE_ANIMATION_BY_TIME_SPRING = 800;
+const EVENT = { translationY: 0 };
+const CTX = { startY: 0 };
+const PARAMS = {
+  isInputFieldFocused: { value: false } as Animated.SharedValue<boolean>,
+  isPanning: { value: false } as Animated.SharedValue<boolean>,
+  isPanningDown: { value: false } as Animated.SharedValue<boolean>,
+  isCardCollapsed: { value: false } as Animated.SharedValue<boolean>,
+  isAnimationRunning: { value: false } as Animated.SharedValue<boolean>,
+  isScrollingCard: { value: false } as Animated.SharedValue<boolean>,
+  prevDragY: { value: 0 } as Animated.SharedValue<number>,
+  dragY: { value: 0 } as Animated.SharedValue<number>,
+  translationY: { value: 0 } as Animated.SharedValue<number>,
+  innerScrollY: { value: 0 } as Animated.SharedValue<number>,
+  snapPointBottom: { value: 0 } as Animated.SharedValue<number>,
+  type: '' as string,
+};
+
+const mockRunOnJSDismissKeyboard = jest.fn();
+
+jest.mock('react-native-reanimated', () => ({
+  __esModule: true,
+  ...jest.requireActual('react-native-reanimated'),
+  runOnJS: (): typeof jest.fn => mockRunOnJSDismissKeyboard,
+}));
+
+describe('src/worklets/onActionRequestCloseOrOpenCard', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('onStart', () => {
+    it(`should ensure that the initial ctx.startY value takes a transition event
+    from scrolling to panning into account by being equal to translationY.value - innerScrollY.value,
+    when type is content`, () => {
+      renderHook(() => {
+        PARAMS.translationY = useSharedValue(100);
+        PARAMS.innerScrollY = useSharedValue(50);
+        PARAMS.isPanningDown = useSharedValue(false);
+        PARAMS.type = 'content';
+      });
+
+      const { onStart } = onGestureHandlerCard(PARAMS);
+
+      onStart({}, CTX);
+
+      expect(PARAMS.type).toEqual('content');
+      expect(CTX.startY).toEqual(50);
+    });
+
+    it('should ensure that ctx.startY equals translationY.value when type is header', () => {
+      renderHook(() => {
+        PARAMS.translationY = useSharedValue(100);
+        PARAMS.innerScrollY = useSharedValue(50);
+        PARAMS.isPanningDown = useSharedValue(false);
+        PARAMS.type = 'header';
+      });
+
+      const { onStart } = onGestureHandlerCard(PARAMS);
+
+      onStart({}, CTX);
+
+      expect(PARAMS.type).toEqual('header');
+      expect(CTX.startY).toEqual(100);
+    });
+  });
+
+  describe('onActive', () => {
+    describe('Input field is not focused: Update relevant gesture handler values', () => {
+      PARAMS.isInputFieldFocused.value = false;
+
+      it('should update prevDragY.value so it is equal to latest translationY.value', () => {
+        renderHook(() => {
+          PARAMS.translationY = useSharedValue(100);
+          PARAMS.prevDragY = useSharedValue(0);
+        });
+
+        const { onActive } = onGestureHandlerCard(PARAMS);
+
+        onActive(EVENT, CTX);
+
+        expect(PARAMS.prevDragY.value).toEqual(100);
+      });
+
+      it('should update dragY.value so it represents the y gesture handling which equals ctx.startY + event.translationY', () => {
+        CTX.startY = 100;
+        EVENT.translationY = 100;
+
+        renderHook(() => {
+          PARAMS.dragY = useSharedValue(0);
+        });
+
+        const { onActive } = onGestureHandlerCard(PARAMS);
+
+        onActive(EVENT, CTX);
+
+        expect(PARAMS.dragY.value).toEqual(200);
+      });
+
+      describe('User is dragging within limitations: dragY.value is higher than 0', () => {
+        describe('User is scrolling: smooth transition from scrolling to panning', () => {
+          it('should update translationY.value to dragY.value if the innerScrollY.value is 0', () => {
+            renderHook(() => {
+              PARAMS.isScrollingCard = useSharedValue(true);
+              PARAMS.translationY = useSharedValue(0);
+              PARAMS.prevDragY = useSharedValue(0);
+              PARAMS.innerScrollY = useSharedValue(0);
+              PARAMS.dragY = useSharedValue(CTX.startY + EVENT.translationY);
+              PARAMS.type = 'content';
+            });
+
+            const { onActive } = onGestureHandlerCard(PARAMS);
+
+            onActive(EVENT, CTX);
+
+            expect(PARAMS.translationY.value).toEqual(PARAMS.dragY.value);
+            expect(PARAMS.translationY.value).toEqual(200);
+          });
+
+          it(`should update translationY.value to dragY.value if the innerScrollY.value is less or equal to the
+          scroll event throttle of 16`, () => {
+            renderHook(() => {
+              PARAMS.translationY = useSharedValue(0);
+              PARAMS.isScrollingCard = useSharedValue(true);
+              PARAMS.prevDragY = useSharedValue(0);
+              PARAMS.innerScrollY = useSharedValue(16);
+              PARAMS.dragY = useSharedValue(CTX.startY + EVENT.translationY);
+              PARAMS.type = 'content';
+            });
+
+            const { onActive } = onGestureHandlerCard(PARAMS);
+
+            onActive(EVENT, CTX);
+
+            expect(PARAMS.translationY.value).toEqual(PARAMS.dragY.value);
+            expect(PARAMS.translationY.value).toEqual(200);
+          });
+
+          it(`should not update translationY.value to dragY.value if the innerScrollY.value is higher than the
+          scroll event throttle of 16`, () => {
+            renderHook(() => {
+              PARAMS.translationY = useSharedValue(0);
+              PARAMS.isScrollingCard = useSharedValue(true);
+              PARAMS.prevDragY = useSharedValue(0);
+              PARAMS.innerScrollY = useSharedValue(17);
+              PARAMS.dragY = useSharedValue(CTX.startY + EVENT.translationY);
+              PARAMS.type = 'content';
+            });
+
+            const { onActive } = onGestureHandlerCard(PARAMS);
+
+            onActive(EVENT, CTX);
+
+            expect(PARAMS.translationY.value).not.toEqual(PARAMS.dragY.value);
+            expect(PARAMS.translationY.value).toEqual(0);
+          });
+        });
+
+        describe('User is not scrolling', () => {
+          it('should update translationY.value to dragY.value', () => {
+            renderHook(() => {
+              PARAMS.isScrollingCard = useSharedValue(false);
+              PARAMS.translationY = useSharedValue(0);
+              PARAMS.innerScrollY = useSharedValue(0);
+              PARAMS.dragY = useSharedValue(CTX.startY + EVENT.translationY);
+              PARAMS.type = 'content';
+            });
+
+            const { onActive } = onGestureHandlerCard(PARAMS);
+
+            onActive(EVENT, CTX);
+
+            expect(PARAMS.translationY.value).toEqual(PARAMS.dragY.value);
+            expect(PARAMS.translationY.value).toEqual(200);
+          });
+        });
+      });
+
+      describe('User is dragging outside limitations dragY.value is less or equal to 0', () => {
+        it('should not update translationY.value to dragY.value', () => {
+          CTX.startY = 0;
+          EVENT.translationY = 0;
+
+          renderHook(() => {
+            PARAMS.isInputFieldFocused = useSharedValue(false);
+            PARAMS.dragY = useSharedValue(CTX.startY + EVENT.translationY);
+            PARAMS.translationY = useSharedValue(0);
+          });
+
+          const { onActive } = onGestureHandlerCard(PARAMS);
+
+          onActive(EVENT, CTX);
+
+          expect(PARAMS.translationY.value).not.toEqual(-20);
+          expect(PARAMS.translationY.value).toEqual(0);
+        });
+      });
+    });
+
+    describe('Input field is focused: Do not update relevant gesture handler values', () => {
+      it('should not update translationY.value to dragY.value', () => {
+        CTX.startY = 0;
+        EVENT.translationY = -20;
+
+        renderHook(() => {
+          PARAMS.isInputFieldFocused = useSharedValue(true);
+          PARAMS.dragY = useSharedValue(CTX.startY + EVENT.translationY);
+          PARAMS.translationY = useSharedValue(0);
+        });
+
+        const { onActive } = onGestureHandlerCard(PARAMS);
+
+        onActive(EVENT, CTX);
+
+        expect(PARAMS.translationY.value).not.toEqual(PARAMS.dragY.value);
+        expect(PARAMS.translationY.value).toEqual(0);
+      });
+    });
+  });
+
+  describe('onEnd', () => {
+    it(`should update isPanning.value and isCardCollapsed.value to true when the user is dragging
+    down which is derived from when prevDragY.value is less than dragY.value`, () => {
+      CTX.startY = 50;
+      EVENT.translationY = 50;
+
+      renderHook(() => {
+        PARAMS.isPanningDown = useSharedValue(false);
+        PARAMS.isCardCollapsed = useSharedValue(false);
+        PARAMS.dragY = useSharedValue(CTX.startY + EVENT.translationY);
+        PARAMS.translationY = useSharedValue(200);
+      });
+
+      const { onEnd } = onGestureHandlerCard(PARAMS);
+
+      onEnd(EVENT);
+
+      expect(PARAMS.isPanningDown.value).toBeTruthy();
+      expect(PARAMS.isCardCollapsed.value).toBeTruthy();
+    });
+
+    it(`should update isPanning.value and isCardCollapsed.value to false when the user is dragging
+    up which is derived from when prevDragY.value is higher than dragY.value`, () => {
+      renderHook(() => {
+        PARAMS.isPanningDown = useSharedValue(true);
+        PARAMS.isCardCollapsed = useSharedValue(true);
+        PARAMS.dragY = useSharedValue(CTX.startY + EVENT.translationY);
+        PARAMS.prevDragY = useSharedValue(CTX.startY + EVENT.translationY + 1);
+        PARAMS.translationY = useSharedValue(0);
+      });
+
+      const { onEnd } = onGestureHandlerCard(PARAMS);
+
+      onEnd(EVENT);
+
+      expect(PARAMS.isPanningDown.value).toBeFalsy();
+      expect(PARAMS.isCardCollapsed.value).toBeFalsy();
+    });
+
+    it('should set isAnimationRunning.value to true and isPanning.value to false', () => {
+      renderHook(() => {
+        PARAMS.isPanning = useSharedValue(true);
+        PARAMS.isAnimationRunning = useSharedValue(false);
+      });
+
+      const { onEnd } = onGestureHandlerCard(PARAMS);
+
+      onEnd(EVENT);
+
+      expect(PARAMS.isPanning.value).toBeFalsy();
+      expect(PARAMS.isAnimationRunning.value).toBeTruthy();
+    });
+
+    describe('Input field is focused', () => {
+      it('should dismiss keyboard if isInputFieldFocused.value is true and innerScrollY.value is 0', () => {
+        renderHook(() => {
+          PARAMS.isInputFieldFocused = useSharedValue(true);
+          PARAMS.innerScrollY = useSharedValue(0);
+        });
+
+        const { onEnd } = onGestureHandlerCard(PARAMS);
+
+        onEnd(EVENT);
+
+        expect(mockRunOnJSDismissKeyboard).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('Input field is not focused', () => {
+      it('should open card if user is not panning down so that the translationY.value updates to 0', () => {
+        withReanimatedTimer(() => {
+          renderHook(() => {
+            PARAMS.snapPointBottom = useSharedValue(200);
+            PARAMS.isInputFieldFocused = useSharedValue(false);
+            PARAMS.prevDragY = useSharedValue(200);
+            PARAMS.translationY = useSharedValue(100);
+          });
+
+          const { onEnd } = onGestureHandlerCard(PARAMS);
+
+          onEnd(EVENT);
+
+          expect(PARAMS.isAnimationRunning.value).toBeTruthy();
+
+          advanceAnimationByTime(ADVANCE_ANIMATION_BY_TIME_SPRING);
+
+          expect(PARAMS.isAnimationRunning.value).toBeFalsy();
+          expect(PARAMS.translationY.value).not.toEqual(PARAMS.snapPointBottom.value);
+          expect(PARAMS.translationY.value).toBe(0);
+        });
+      });
+
+      it('should close card if user is panning down so that the translationY.value updates to snapPointBottom.value', () => {
+        withReanimatedTimer(() => {
+          renderHook(() => {
+            PARAMS.snapPointBottom = useSharedValue(200);
+            PARAMS.isInputFieldFocused = useSharedValue(false);
+            PARAMS.prevDragY = useSharedValue(100);
+            PARAMS.translationY = useSharedValue(200);
+          });
+
+          const { onEnd } = onGestureHandlerCard(PARAMS);
+
+          onEnd(EVENT);
+
+          expect(PARAMS.isAnimationRunning.value).toBeTruthy();
+
+          advanceAnimationByTime(ADVANCE_ANIMATION_BY_TIME_SPRING);
+
+          expect(PARAMS.translationY.value).toEqual(PARAMS.snapPointBottom.value);
+          expect(PARAMS.translationY.value).toBe(200);
+        });
+      });
+
+      it('should not execute dismiss keyboard function when keyboard is not visible', () => {
+        renderHook(() => {
+          PARAMS.isInputFieldFocused = useSharedValue(false);
+        });
+
+        const { onEnd } = onGestureHandlerCard(PARAMS);
+
+        onEnd(EVENT);
+
+        expect(mockRunOnJSDismissKeyboard).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/src/worklets/index.ts
+++ b/src/worklets/index.ts
@@ -2,7 +2,7 @@ export { onActionRequestCloseOrOpenCard } from './onActionRequestCloseOrOpenCard
 export { onOuterScrollReaction } from './onOuterScrollReaction';
 export { onScrollRequestCloseOrOpenCard } from './onScrollRequestCloseOrOpenCard';
 export { getAnimatedCardStyles } from './getAnimatedCardStyles';
-export { getGestures } from './getGestures';
+export { onGestureHandlerCard } from './onGestureHandlerCard';
 export { onGestureHandlerSnapEffect } from './onGestureHandlerSnapEffect';
 export { onSnappableReaction } from './onSnappableReaction';
 export { onResetCardAndSlideToTopOrBottom } from './onResetCardAndSlideToTopOrBottom';

--- a/src/worklets/onGestureHandlerCard.ts
+++ b/src/worklets/onGestureHandlerCard.ts
@@ -1,0 +1,96 @@
+import Animated, { runOnJS, withSpring } from 'react-native-reanimated';
+import { Keyboard } from 'react-native';
+import { DEFAULT_SNAP_POINT_TOP, DEFAULT_SPRING_CONFIG } from '../constants/animations';
+import { SCROLL_EVENT_THROTTLE } from '../constants/configs';
+
+interface Props {
+  isInputFieldFocused: Animated.SharedValue<boolean>;
+  isPanning: Animated.SharedValue<boolean>;
+  isPanningDown: Animated.SharedValue<boolean>;
+  isCardCollapsed: Animated.SharedValue<boolean>;
+  isAnimationRunning: Animated.SharedValue<boolean>;
+  isScrollingCard: Animated.SharedValue<boolean>;
+  prevDragY: Animated.SharedValue<number>;
+  dragY: Animated.SharedValue<number>;
+  translationY: Animated.SharedValue<number>;
+  innerScrollY: Animated.SharedValue<number>;
+  snapPointBottom: Animated.SharedValue<number>;
+  type: string;
+}
+
+interface ReturnFunctionTypes {
+  onStart: (_: Record<string, number>, ctx: Record<string, number>) => void;
+  onActive: (event: Record<string, number>, ctx: Record<string, number>) => void;
+  onEnd: (event: Record<string, number>) => void;
+}
+
+export const onGestureHandlerCard = ({
+  isInputFieldFocused,
+  isPanning,
+  isPanningDown,
+  isCardCollapsed,
+  isAnimationRunning,
+  isScrollingCard,
+  prevDragY,
+  dragY,
+  translationY,
+  snapPointBottom,
+  innerScrollY,
+  type,
+}: Props): ReturnFunctionTypes => ({
+  onStart: (_, ctx): void => {
+    'worklet';
+
+    ctx.startY = type === 'content' ? translationY.value - innerScrollY.value : translationY.value;
+  },
+  onActive: (event, ctx): void => {
+    'worklet';
+
+    if (!isInputFieldFocused.value) {
+      isPanning.value = prevDragY.value !== translationY.value;
+      prevDragY.value = translationY.value;
+      dragY.value = ctx.startY + event.translationY;
+
+      if (dragY.value > 0) {
+        if (
+          isScrollingCard.value &&
+          ctx.startY + event.translationY > prevDragY.value &&
+          type === 'content'
+        ) {
+          if (innerScrollY.value === 0 || innerScrollY.value <= SCROLL_EVENT_THROTTLE) {
+            translationY.value = dragY.value;
+          }
+        } else {
+          translationY.value = dragY.value;
+        }
+      }
+    }
+  },
+  onEnd: (event): void => {
+    'worklet';
+
+    const isPanningDownWithFastRelease = prevDragY.value < dragY.value;
+    const isPanningDownWithSlowRelease = prevDragY.value <= dragY.value && event.translationY > 0;
+
+    isPanningDown.value = isPanningDownWithFastRelease || isPanningDownWithSlowRelease;
+    isCardCollapsed.value = isPanningDown.value;
+    isAnimationRunning.value = true;
+    isPanning.value = false;
+
+    if (isInputFieldFocused.value && innerScrollY.value === 0) {
+      runOnJS(Keyboard.dismiss)();
+    }
+
+    if (!isInputFieldFocused.value) {
+      translationY.value = withSpring(
+        isPanningDown.value ? snapPointBottom.value : DEFAULT_SNAP_POINT_TOP,
+        DEFAULT_SPRING_CONFIG,
+        isAnimationComplete => {
+          if (isAnimationComplete) {
+            isAnimationRunning.value = false;
+          }
+        },
+      );
+    }
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -7683,12 +7683,11 @@ react-native-gradle-plugin@^0.0.6:
   resolved "https://registry.yarnpkg.com/react-native-gradle-plugin/-/react-native-gradle-plugin-0.0.6.tgz#b61a9234ad2f61430937911003cddd7e15c72b45"
   integrity sha512-eIlgtsmDp1jLC24dRn43hB3kEcZVqx6DUQbR0N1ABXGnMEafm9I3V3dUUeD1vh+Dy5WqijSoEwLNUPLgu5zDMg==
 
-react-native-reanimated@^2.9.1:
-  version "2.9.1"
-  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-2.9.1.tgz#d9a932e312c13c05b4f919e43ebbf76d996e0bc1"
-  integrity sha512-309SIhDBwY4F1n6e5Mr5D1uPZm2ESIcmZsGXHUu8hpKX4oIOlZj2MilTk+kHhi05LjChoJkcpfkstotCJmPRPg==
+react-native-reanimated@2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-2.8.0.tgz#93c06ca84d91fb3865110b0857c49a24e316130e"
+  integrity sha512-kJvf/UWLBMaGCs9X66MKq5zdFMgwx8D0nHnolbHR7s8ZnbLdb7TlQ/yuzIXqn/9wABfnwtNRI3CyaP1aHWMmZg==
   dependencies:
-    "@babel/plugin-proposal-export-namespace-from" "^7.17.12"
     "@babel/plugin-transform-object-assign" "^7.16.7"
     "@babel/preset-typescript" "^7.16.7"
     "@types/invariant" "^2.2.35"


### PR DESCRIPTION
Unfortunately a bug has been observed where the screen freezes when pressing / entering and returning to the overview. This bug is only on iOS.

I have tried everything to debug it. The conclusion is related https://github.com/software-mansion/react-native-reanimated/issues/3331. The new gesture component GestureDetector do not handle on mount very well.

I had three possible solutions:

Reintroduce old working gesture handling solution
Combine old and new RNGH solution and add a prop useLatestRNGH to determine which one to use
Debug and figure out what is the problem
I started with solution 3, which is currently in place (previous version). I removed the defined 'worklet' approach which causes a bad warning as RNGH gets confused on what thread to use. But it worked. The debugging is pure guessing as there is no proper debugging information for worklets when working with the UI thread.

I tried to do solution 2 but it introduces ALOT of extra code and make readability and complexity ALOT more difficult.

*** The only viable solution is 1: remove latest RNGH2.0 and go back to reanimated useAnimatedGestureHandler and wait for RNGH to fix their GestureDetector ***